### PR TITLE
Disabled Register button after click event

### DIFF
--- a/thavalon-webapp/src/components/Register.tsx
+++ b/thavalon-webapp/src/components/Register.tsx
@@ -9,11 +9,13 @@ ReactModal.setAppElement("#root");
 function Login() {
     const [modalIsOpen, setModalIsOpen] = useState(true);
     const {register, handleSubmit, errors} = useForm();
+    const [disable, setDisabled] = useState(false);
     function closeModal() {
         setModalIsOpen(false);
     }
 
     function onError(data: any, event: any) {
+        setDisabled(false);
         console.log(data);
         console.log("ERROR");
         event.preventDefault();
@@ -67,7 +69,7 @@ function Login() {
                     ref={register({required: true})} />
                 {errors.confirmPassword && <span className="errorMsg">Password required.</span>}
                 <br />
-                <input type="submit" value="Register" />
+                <input type="submit" onClick={() => setDisabled(true)} disabled={disable} value="Register" />
             </form>
         </ReactModal>
     )


### PR DESCRIPTION
Fixes #26 

Hello! I requested to be assigned the issue but with it being a holiday I understand that you might be busy doing other things. I decided to go ahead and fix the issue.

The Register button is now disabled when clicked, and if there was an error with the form it is re-enabled.

Please let me know if you'd like me to make any changes to the PR.