### PR TITLE
Messages to select/unselect players

### DIFF
--- a/thavalon-server/src/game/messages.rs
+++ b/thavalon-server/src/game/messages.rs
@@ -59,11 +59,10 @@ pub enum Message {
         max_proposals: usize,
     },
 
-    /// A player was added to the current proposal
-    PlayerSelected { player: String },
-
-    /// A player was removed from the current proposal
-    PlayerUnselected { player: String },
+    /// The current proposal was updated
+    ProposalUpdated {
+        players: HashSet<String>
+    },
 
     /// Announces that a player made a proposal
     ProposalMade {

--- a/thavalon-server/src/game/messages.rs
+++ b/thavalon-server/src/game/messages.rs
@@ -16,6 +16,12 @@ pub enum Action {
     Propose {
         players: HashSet<String>,
     },
+    SelectPlayer {
+        player: String,
+    },
+    UnselectPlayer {
+        player: String,
+    },
     Vote {
         upvote: bool,
     },
@@ -52,6 +58,12 @@ pub enum Message {
         /// The maximum number of unsent proposals before force activates
         max_proposals: usize,
     },
+
+    /// A player was added to the current proposal
+    PlayerSelected { player: String },
+
+    /// A player was removed from the current proposal
+    PlayerUnselected { player: String },
 
     /// Announces that a player made a proposal
     ProposalMade {

--- a/thavalon-server/src/game/state.rs
+++ b/thavalon-server/src/game/state.rs
@@ -221,6 +221,12 @@ impl GameStateWrapper {
             (GameStateWrapper::Proposing(inner), Action::Propose { players }) => {
                 inner.handle_proposal(player, players)
             }
+            (GameStateWrapper::Proposing(inner), Action::SelectPlayer { player: selected }) => {
+                inner.handle_player_selected(player, selected)
+            }
+            (GameStateWrapper::Proposing(inner), Action::UnselectPlayer { player: unselected }) => {
+                inner.handle_player_unselected(player, unselected)
+            }
             (GameStateWrapper::Voting(inner), Action::Vote { upvote }) => {
                 inner.handle_vote(player, upvote)
             }

--- a/thavalon-server/src/game/state/assassination.rs
+++ b/thavalon-server/src/game/state/assassination.rs
@@ -56,7 +56,7 @@ impl GameState<Assassination> {
                     } else {
                         return self.player_error(format!("{} is not in the game", name));
                     }
-                }    
+                }
             }
 
             let effects = vec![Effect::Broadcast(Message::AssassinationResult {

--- a/thavalon-server/src/game/state/proposing.rs
+++ b/thavalon-server/src/game/state/proposing.rs
@@ -16,8 +16,8 @@ impl GameState<Proposing> {
         }
 
         self.phase.selected_players.insert(added_player.clone());
-        let effects = vec![Effect::Broadcast(Message::PlayerSelected {
-            player: added_player,
+        let effects = vec![Effect::Broadcast(Message::ProposalUpdated {
+            players: self.phase.selected_players.clone(),
         })];
 
         (GameStateWrapper::Proposing(self), effects)
@@ -33,8 +33,8 @@ impl GameState<Proposing> {
         }
 
         if self.phase.selected_players.remove(&removed_player) {
-            let effects = vec![Effect::Broadcast(Message::PlayerUnselected {
-                player: removed_player,
+            let effects = vec![Effect::Broadcast(Message::ProposalUpdated {
+                players: self.phase.selected_players.clone(),
             })];
 
             (GameStateWrapper::Proposing(self), effects)


### PR DESCRIPTION
This adds actions (`SelectPlayer` and `UnselectPlayer`) and a message (`ProposalUpdated`) for the proposer to select/unselect players they are thinking of proposing. It doesn't change how submitting the official proposal works though, so all validation is still done there.