### PR TITLE
[77] Add message support for lovers

### DIFF
--- a/thavalon-server/src/game/engine.rs
+++ b/thavalon-server/src/game/engine.rs
@@ -76,9 +76,6 @@ pub async fn run_game<I: Interactions>(game: Game, interactions: &mut I) -> Resu
                     timeout = time::delay_for(duration).right_future();
                 }
                 Effect::ClearTimeout => timeout = future::pending().left_future(),
-                Effect::MessagePlayer(message, receiving_player) => {
-                    interactions.send_to(&receiving_player, message).await;
-                }
             }
         }
         state = next_state;

--- a/thavalon-server/src/game/engine.rs
+++ b/thavalon-server/src/game/engine.rs
@@ -69,6 +69,9 @@ pub async fn run_game<I: Interactions>(game: Game, interactions: &mut I) -> Resu
                     timeout = time::delay_for(duration).right_future();
                 }
                 Effect::ClearTimeout => timeout = future::pending().left_future(),
+                Effect::MessagePlayer(message, receiving_player) => {
+                    interactions.send_to(&receiving_player, message).await;
+                }
             }
         }
         state = next_state;

--- a/thavalon-server/src/game/messages.rs
+++ b/thavalon-server/src/game/messages.rs
@@ -133,7 +133,7 @@ pub enum Message {
     LoversInfo {
         lone_lover: bool,
         lover_on_mission: bool,
-        lover_identity: String,
+        lover_identity: Option<String>,
     },
 }
 

--- a/thavalon-server/src/game/messages.rs
+++ b/thavalon-server/src/game/messages.rs
@@ -129,12 +129,20 @@ pub enum Message {
         roles: HashMap<String, RoleDetails>,
     },
 
-    /// Information sent to lovers specific to their role after each mission.
-    LoversInfo {
-        lone_lover: bool,
-        lover_on_mission: bool,
-        lover_identity: Option<String>,
-    },
+    /// Message that a client should surface to the end user.
+    Toast {
+        severity: ToastSeverity,
+        message: String
+    }
+}
+
+/// Severity of a toast notification
+#[derive(Debug, Clone, Eq, PartialEq, Serialize)]
+#[serde(tag = "toastSeverity")]
+pub enum ToastSeverity {
+    INFO,
+    WARN,
+    URGENT
 }
 
 /// How players voted on a proposal

--- a/thavalon-server/src/game/messages.rs
+++ b/thavalon-server/src/game/messages.rs
@@ -125,6 +125,13 @@ pub enum Message {
         winning_team: Team,
         roles: HashMap<String, RoleDetails>,
     },
+
+    /// Information sent to lovers specific to their role after each mission.
+    LoversInfo {
+        lone_lover: bool,
+        lover_on_mission: bool,
+        lover_identity: String,
+    },
 }
 
 /// How players voted on a proposal

--- a/thavalon-server/src/game/mod.rs
+++ b/thavalon-server/src/game/mod.rs
@@ -179,7 +179,7 @@ impl Game {
 
     /// Look up the display name associated with a given role, if it exists.
     pub fn display_name_from_role(&self, role: Role) -> Option<&String> {
-        self.info.keys().find(|&x| self.info.get(x).unwrap().get_role() == role)
+        self.info.iter().find_map(|(player, info)| if info.get_role() == role { Some(player) } else { None })
     }
 }
 

--- a/thavalon-server/src/game/mod.rs
+++ b/thavalon-server/src/game/mod.rs
@@ -169,6 +169,11 @@ impl Game {
     pub fn size(&self) -> usize {
         self.proposal_order.len()
     }
+
+    /// Look up the display name associated with a given role, if it exists.
+    pub fn display_name_from_role(&self, role: Role) -> Option<&String> {
+        return self.info.keys().find(|&x| self.info.get(x).unwrap().role == role);
+    }
 }
 
 impl Players {

--- a/thavalon-server/src/game/mod.rs
+++ b/thavalon-server/src/game/mod.rs
@@ -172,7 +172,7 @@ impl Game {
 
     /// Look up the display name associated with a given role, if it exists.
     pub fn display_name_from_role(&self, role: Role) -> Option<&String> {
-        return self.info.keys().find(|&x| self.info.get(x).unwrap().role == role);
+        self.info.keys().find(|&x| self.info.get(x).unwrap().get_role() == role)
     }
 }
 

--- a/thavalon-server/src/game/role.rs
+++ b/thavalon-server/src/game/role.rs
@@ -35,8 +35,7 @@ pub struct RoleDetails {
     /// The team the player is on.
     team: Team,
     /// The player's role.
-    /// TODO: marking this as pub is a hack. What should we be doing instead?
-    pub role: Role,
+    role: Role,
     /// A high-level description of the role.
     description: String,
     /// Other players that this player sees.
@@ -53,6 +52,10 @@ pub struct RoleDetails {
     is_assassin: bool,
     /// If the player is the Assassin, this is the Priority Target that they may assassinate.
     priority_target: Option<PriorityTarget>,
+}
+
+impl RoleDetails {
+    pub fn get_role(&self) -> Role { self.role }
 }
 
 /// A priority assassination target. If the Good team passes 3 missions, then the Assassin must correctly identify

--- a/thavalon-server/src/game/role.rs
+++ b/thavalon-server/src/game/role.rs
@@ -35,7 +35,8 @@ pub struct RoleDetails {
     /// The team the player is on.
     team: Team,
     /// The player's role.
-    role: Role,
+    /// TODO: marking this as pub is a hack. What should we be doing instead?
+    pub role: Role,
     /// A high-level description of the role.
     description: String,
     /// Other players that this player sees.

--- a/thavalon-server/src/game/state.rs
+++ b/thavalon-server/src/game/state.rs
@@ -101,7 +101,6 @@ pub enum Effect {
     Send(String, Message),
     StartTimeout(Duration),
     ClearTimeout,
-    MessagePlayer(Message, String),
 }
 
 pub struct Proposal {

--- a/thavalon-server/src/game/state.rs
+++ b/thavalon-server/src/game/state.rs
@@ -87,7 +87,7 @@ mod prelude {
     pub use super::voting::Voting;
 
     pub use super::super::{
-        messages::{self, Action, Message},
+        messages::{self, Action, Message, ToastSeverity},
         role::{PriorityTarget, Role, Team},
         Card, Game, GameSpec,
     };

--- a/thavalon-server/src/game/state.rs
+++ b/thavalon-server/src/game/state.rs
@@ -99,6 +99,7 @@ pub enum Effect {
     Broadcast(Message),
     StartTimeout(Duration),
     ClearTimeout,
+    MessagePlayer(Message, String),
 }
 
 pub struct Proposal {

--- a/thavalon-server/src/game/state/on_mission.rs
+++ b/thavalon-server/src/game/state/on_mission.rs
@@ -129,17 +129,17 @@ impl GameState<OnMission> {
         let iseult_on_mission = iseult_display_name.map_or(None, |x| Some(self.proposals.get(self.phase.proposal_index).unwrap().players.contains(x)));
         // First, add messages going to Tristan. If there is no Tristan, do nothing.
         if tristan_display_name.is_some() {
-            effects.push(self.build_lover_effect(&tristan_display_name.unwrap(), tristan_on_mission.unwrap(), iseult_display_name, iseult_on_mission));
+            effects.push(self.build_lover_effect(tristan_display_name.unwrap(), tristan_on_mission.unwrap(), iseult_display_name, iseult_on_mission));
         }
         // Next do the same for Iseult.
         if iseult_display_name.is_some() {
-            effects.push(self.build_lover_effect(&iseult_display_name.unwrap(), iseult_on_mission.unwrap(), tristan_display_name, tristan_on_mission));
+            effects.push(self.build_lover_effect(iseult_display_name.unwrap(), iseult_on_mission.unwrap(), tristan_display_name, tristan_on_mission));
         }
     }
 
     // Builds a message for a player, given information about their lover who may not exist.
     fn build_lover_effect(&self, player_display_name: &str, player_on_mission: bool, opt_lover_display_name: Option<&String>, opt_lover_on_mission: Option<bool>) -> Effect {        
-        let inner_message = opt_lover_on_mission.map_or("does not exist. You're alone :(".to_owned(), 
+        let inner_message = opt_lover_on_mission.map_or("does not exist. You're alone :'(".to_owned(), 
                             |x| if x { if player_on_mission {format!("was on the mission with you, it's {}", opt_lover_display_name.unwrap())} 
                                         else {"was on this mission.".to_owned()}}
                                 else {"was not on this mission.".to_owned()});

--- a/thavalon-server/src/game/state/on_mission.rs
+++ b/thavalon-server/src/game/state/on_mission.rs
@@ -124,16 +124,16 @@ impl GameState<OnMission> {
     // so this is safe to call in any game.
     fn add_lover_effects(&self, effects: &mut Vec<Effect>) {
         let tristan_display_name = self.game.display_name_from_role(Role::Tristan);
-        let tristan_on_mission = tristan_display_name.map_or(None, |x| Some(self.proposals.get(self.phase.proposal_index).unwrap().players.contains(x)));
+        let tristan_on_mission = tristan_display_name.map_or(None, |x| Some(self.proposal().players.contains(x)));
         let iseult_display_name = self.game.display_name_from_role(Role::Iseult);
-        let iseult_on_mission = iseult_display_name.map_or(None, |x| Some(self.proposals.get(self.phase.proposal_index).unwrap().players.contains(x)));
+        let iseult_on_mission = iseult_display_name.map_or(None, |x| Some(self.proposal().players.contains(x)));
         // First, add messages going to Tristan. If there is no Tristan, do nothing.
-        if tristan_display_name.is_some() {
-            effects.push(self.build_lover_effect(tristan_display_name.unwrap(), tristan_on_mission.unwrap(), iseult_display_name, iseult_on_mission));
+        if let Some(tristan_display_name) = tristan_display_name {
+            effects.push(self.build_lover_effect(tristan_display_name, tristan_on_mission.unwrap(), iseult_display_name, iseult_on_mission));
         }
         // Next do the same for Iseult.
-        if iseult_display_name.is_some() {
-            effects.push(self.build_lover_effect(iseult_display_name.unwrap(), iseult_on_mission.unwrap(), tristan_display_name, tristan_on_mission));
+        if let Some(iseult_display_name) = iseult_display_name {
+            effects.push(self.build_lover_effect(iseult_display_name, iseult_on_mission.unwrap(), tristan_display_name, tristan_on_mission));
         }
     }
 
@@ -144,10 +144,12 @@ impl GameState<OnMission> {
                                         else {"was on this mission.".to_owned()}}
                                 else {"was not on this mission.".to_owned()});
         let toast_message = ["Your lover ", &inner_message].concat();
-        Effect::MessagePlayer(Message::Toast { 
-            severity: ToastSeverity::INFO,
-            message: toast_message,
-        }, player_display_name.to_string())
+        Effect::Send(
+            player_display_name.to_string(),
+            Message::Toast { 
+                severity: ToastSeverity::INFO,
+                message: toast_message,
+            })
     }
 }
 

--- a/thavalon-server/src/game/state/on_mission.rs
+++ b/thavalon-server/src/game/state/on_mission.rs
@@ -138,11 +138,15 @@ impl GameState<OnMission> {
     }
 
     // Builds a message for a player, given information about their lover who may not exist.
-    fn build_lover_effect(&self, player_display_name: &str, player_on_mission: bool, opt_lover_display_name: Option<&String>, opt_lover_on_mission: Option<bool>) -> Effect {
-        Effect::MessagePlayer(Message::LoversInfo { 
-            lone_lover: opt_lover_on_mission.is_none(), 
-            lover_on_mission: opt_lover_on_mission.map_or(false, |x| x),
-            lover_identity: opt_lover_on_mission.map_or(None, |x| if x && player_on_mission {Some(opt_lover_display_name.unwrap().clone())} else {None}) 
+    fn build_lover_effect(&self, player_display_name: &str, player_on_mission: bool, opt_lover_display_name: Option<&String>, opt_lover_on_mission: Option<bool>) -> Effect {        
+        let inner_message = opt_lover_on_mission.map_or("does not exist. You're alone :(".to_owned(), 
+                            |x| if x { if player_on_mission {format!("was on the mission with you, it's {}", opt_lover_display_name.unwrap())} 
+                                        else {"was on this mission.".to_owned()}}
+                                else {"was not on this mission.".to_owned()});
+        let toast_message = ["Your lover ", &inner_message].concat();
+        Effect::MessagePlayer(Message::Toast { 
+            severity: ToastSeverity::INFO,
+            message: toast_message,
         }, player_display_name.to_string())
     }
 }

--- a/thavalon-server/src/game/state/on_mission.rs
+++ b/thavalon-server/src/game/state/on_mission.rs
@@ -124,45 +124,26 @@ impl GameState<OnMission> {
     // so this is safe to call in any game.
     fn add_lover_effects(&self, effects: &mut Vec<Effect>) {
         let tristan_display_name = self.game.display_name_from_role(Role::Tristan);
-        let tristan_on_mission = match tristan_display_name {
-            Some(name) => Some(self.proposals.get(self.phase.proposal_index).unwrap().players.contains(name)),
-            None => None,
-        };
+        let tristan_on_mission = tristan_display_name.map_or(None, |x| Some(self.proposals.get(self.phase.proposal_index).unwrap().players.contains(x)));
         let iseult_display_name = self.game.display_name_from_role(Role::Iseult);
-        let iseult_on_mission = match iseult_display_name {
-            Some(name) => Some(self.proposals.get(self.phase.proposal_index).unwrap().players.contains(name)),
-            None => None,
-        };
+        let iseult_on_mission = iseult_display_name.map_or(None, |x| Some(self.proposals.get(self.phase.proposal_index).unwrap().players.contains(x)));
         // First, add messages going to Tristan. If there is no Tristan, do nothing.
         if tristan_display_name.is_some() {
-            effects.push(self.build_lover_effect(&tristan_display_name.unwrap().as_ref(), tristan_on_mission.unwrap(), iseult_display_name, iseult_on_mission));
+            effects.push(self.build_lover_effect(&tristan_display_name.unwrap(), tristan_on_mission.unwrap(), iseult_display_name, iseult_on_mission));
         }
         // Next do the same for Iseult.
         if iseult_display_name.is_some() {
-            effects.push(self.build_lover_effect(&iseult_display_name.unwrap().as_ref(), iseult_on_mission.unwrap(), tristan_display_name, tristan_on_mission));
+            effects.push(self.build_lover_effect(&iseult_display_name.unwrap(), iseult_on_mission.unwrap(), tristan_display_name, tristan_on_mission));
         }
     }
 
     // Builds a message for a player, given information about their lover who may not exist.
     fn build_lover_effect(&self, player_display_name: &str, player_on_mission: bool, opt_lover_display_name: Option<&String>, opt_lover_on_mission: Option<bool>) -> Effect {
-        return match opt_lover_on_mission {
-            // There is no lover, player is a lone lover. sadge :(
-            None => Effect::MessagePlayer(Message::LoversInfo {lone_lover: true, lover_on_mission: false, lover_identity: String::new()}, player_display_name.to_string()),
-            // There is a lover, who may or may not be on the mission.
-            Some(lover_on_mission) => 
-                if lover_on_mission {
-                    if player_on_mission {
-                        // Both lovers are on the mission, they learn each other's identities.
-                        Effect::MessagePlayer(Message::LoversInfo {lone_lover: false, lover_on_mission: true, lover_identity: opt_lover_display_name.unwrap().clone()}, player_display_name.to_string())
-                    } else {
-                        // Lover is on mission, player is not. Identity is not revealed.
-                        Effect::MessagePlayer(Message::LoversInfo {lone_lover: false, lover_on_mission: true, lover_identity: String::new()}, player_display_name.to_string())
-                    }
-                } else {
-                    // Lover is not on mission but does exist, so player learns this.
-                    Effect::MessagePlayer(Message::LoversInfo {lone_lover: false, lover_on_mission: false, lover_identity: String::new()}, player_display_name.to_string())
-                },
-        };
+        Effect::MessagePlayer(Message::LoversInfo { 
+            lone_lover: opt_lover_on_mission.is_none(), 
+            lover_on_mission: opt_lover_on_mission.map_or(false, |x| x),
+            lover_identity: opt_lover_on_mission.map_or(None, |x| if x && player_on_mission {Some(opt_lover_display_name.unwrap().clone())} else {None}) 
+        }, player_display_name.to_string())
     }
 }
 


### PR DESCRIPTION
fixes #77 

Add message support for lovers. This adds:
-A new message type `Toast` which signals to the front end that something should pop up to the user. Contains a string and a severity enum
-Added effects to send `Toast` messages to lovers at the end of missions containing their lover info.

I didn't add anything to surface these in the frontend, but from logs the messages definitely get sent.