### PR TITLE
[93] Delete games after they finish

### DIFF
--- a/thavalon-server/src/connections/game_handlers.rs
+++ b/thavalon-server/src/connections/game_handlers.rs
@@ -110,9 +110,9 @@ pub async fn create_game(
         .insert(friend_code.clone(), lobby_channel);
 
     // Spawn a thread to monitor this lobby and remove it from game_collection when it's over or timed out.
-    tokio::spawn(async move {
-        monitor_lobby_task(monitor_lobby_channel, end_game_rx, monitor_friend_code, monitor_game_collection).await;
-    });
+    tokio::spawn(
+        monitor_lobby_task(monitor_lobby_channel, end_game_rx, monitor_friend_code, monitor_game_collection)
+    );
 
     let response = NewGameResponse { friend_code };
     Ok(reply::json(&response))

--- a/thavalon-server/src/connections/game_handlers.rs
+++ b/thavalon-server/src/connections/game_handlers.rs
@@ -110,7 +110,7 @@ pub async fn create_game(
 
     // Spawn a thread to monitor this lobby and remove it from game_collection when it's over or timed out.
     tokio::spawn(async move {
-        monitor_lobby(monitor_lobby_channel, monitor_friend_code, monitor_game_collection).await;
+        monitor_lobby_task(monitor_lobby_channel, monitor_friend_code, monitor_game_collection).await;
     });
 
     let response = NewGameResponse { friend_code };

--- a/thavalon-server/src/connections/game_handlers.rs
+++ b/thavalon-server/src/connections/game_handlers.rs
@@ -276,14 +276,14 @@ async fn client_connection(socket: WebSocket, client_id: String, mut lobby_chann
 
 /// Helper function for monitoring a lobby, intended to run as a tokio task. This will remove the lobby from
 /// GameCollection once the lobby ends or exceeds the maximum lobby lifetime.
-async fn monitor_lobby(mut lobby_channel: LobbyChannel, friend_code: String, game_collection: GameCollection) {
-    // Lobby deadline is 6 hours from creation across all phases.
-    let deadline = tokio::time::delay_until(Instant::now() + Duration::from_secs(60 * 60 * 6));
-    let mut deadline_channel = lobby_channel.clone();
+async fn monitor_lobby_task(mut lobby_channel: LobbyChannel, friend_code: String, game_collection: GameCollection) {
+    // Lobby timeout is 6 hours from creation across all phases.
+    let timeout = tokio::time::delay_until(Instant::now() + Duration::from_secs(60 * 60 * 6));
+    let mut timeout_channel = lobby_channel.clone();
     tokio::select! {
-        _ = deadline => {
+        _ = timeout => {
             log::error!("Lobby {} has exceeded timeout, killing this lobby now.", &friend_code);
-            deadline_channel.send((LobbyCommand::EndGame, None)).await;
+            timeout_channel.send((LobbyCommand::EndGame, None)).await;
         }
         _ = monitor_game_for_completion(lobby_channel) => {
             log::info!("Lobby {} completed, removing it from game collection.", &friend_code);

--- a/thavalon-server/src/lobby/lobby_impl.rs
+++ b/thavalon-server/src/lobby/lobby_impl.rs
@@ -427,7 +427,6 @@ impl Lobby {
                     client_id,
                     is_tabbed_out,
                 } => self.player_focus_changed(client_id, is_tabbed_out).await,
-                LobbyCommand::PollLobby => LobbyResponse::None,
             };
 
             if let Some(channel) = result_channel {

--- a/thavalon-server/src/lobby/mod.rs
+++ b/thavalon-server/src/lobby/mod.rs
@@ -72,7 +72,6 @@ pub enum LobbyCommand {
         client_id: String,
         is_tabbed_out: bool,
     },
-    PollLobby,
 }
 
 /// Enum of possible responses from the lobby.

--- a/thavalon-server/src/lobby/mod.rs
+++ b/thavalon-server/src/lobby/mod.rs
@@ -8,6 +8,7 @@ use crate::game::{snapshot::GameSnapshot, Action, Message};
 pub use lobby_impl::Lobby;
 use serde::{Deserialize, Serialize};
 use thiserror::Error;
+use tokio::task;
 use tokio::sync::{mpsc::Sender, oneshot};
 use warp::filters::ws::WebSocket;
 
@@ -57,6 +58,7 @@ pub enum LobbyCommand {
         client_id: String,
     },
     StartGame,
+    EndGame,
     PlayerDisconnect {
         client_id: String,
     },
@@ -70,6 +72,7 @@ pub enum LobbyCommand {
         client_id: String,
         is_tabbed_out: bool,
     },
+    PollLobby,
 }
 
 /// Enum of possible responses from the lobby.


### PR DESCRIPTION
fixes #93 

This changes the way lobbies are managed slightly. When new lobbies are created, a new task is kicked off to monitor the lobby for liveness, polling every minute. When the game ends or a timeout (currently 6h but that's v arbitrary) expires, the lobby ends, which also ends the database game and the actual game thread.