### PR TITLE
[87] Add Nimue

### DIFF
--- a/thavalon-server/src/game/mod.rs
+++ b/thavalon-server/src/game/mod.rs
@@ -294,6 +294,7 @@ static FIVE_PLAYER: GameSpec = GameSpec {
         Role::Percival,
         Role::Tristan,
         Role::Iseult,
+        Role::Nimue,
     ],
     evil_roles: &[
         Role::Mordred,
@@ -317,6 +318,7 @@ static SEVEN_PLAYER: GameSpec = GameSpec {
         Role::Percival,
         Role::Tristan,
         Role::Iseult,
+        Role::Nimue,
     ],
     evil_roles: &[
         Role::Mordred,

--- a/thavalon-server/src/game/role.rs
+++ b/thavalon-server/src/game/role.rs
@@ -13,6 +13,7 @@ pub enum Role {
     Percival,
     Tristan,
     Iseult,
+    Nimue,
 
     Mordred,
     Morgana,
@@ -55,7 +56,9 @@ pub struct RoleDetails {
 }
 
 impl RoleDetails {
-    pub fn get_role(&self) -> Role { self.role }
+    pub fn get_role(&self) -> Role {
+        self.role
+    }
 }
 
 /// A priority assassination target. If the Good team passes 3 missions, then the Assassin must correctly identify
@@ -76,6 +79,7 @@ impl Role {
         Role::Percival,
         Role::Tristan,
         Role::Iseult,
+        Role::Nimue,
     ];
 
     /// All Evil roles
@@ -90,7 +94,7 @@ impl Role {
     pub fn is_good(self) -> bool {
         use Role::*;
         match self {
-            Merlin | Lancelot | Percival | Tristan | Iseult => true,
+            Merlin | Lancelot | Percival | Tristan | Iseult | Nimue => true,
             Mordred | Morgana | Maelegant | Maeve | Agravaine => false,
         }
     }
@@ -172,19 +176,31 @@ impl Role {
                 match priority_target {
                     PriorityTarget::Merlin => {
                         seen_players.push(players.by_role(Role::Merlin).unwrap().name.clone());
-                    },
+                    }
                     PriorityTarget::Lovers => {
                         seen_players.push(players.by_role(Role::Iseult).unwrap().name.clone());
                         seen_players.push(players.by_role(Role::Tristan).unwrap().name.clone());
-                    },
+                    }
                     PriorityTarget::None => (),
-                    other => panic!("Unsupported priority target {:?}", other)
+                    other => panic!("Unsupported priority target {:?}", other),
                 }
             }
             Role::Tristan | Role::Iseult => {
                 let _ = writeln!(
                     &mut description,
                     "You may or may not see your Lover at some point I guess? Once you and your Lover go on a mission together, you will be revealed to each other. Until then, you will be told after each mission if it contained your Lover."
+                );
+            }
+            Role::Nimue => {
+                let _ = writeln!(
+                    &mut description,
+                    "You see all Good roles in the game, but not who has which role."
+                );
+                seen_players.extend(
+                    players
+                        .iter()
+                        .filter(|p| p.role.is_good())
+                        .map(|player| player.role.to_string()),
                 );
             }
             Role::Mordred => {


### PR DESCRIPTION
This adds backend support for Nimue. Since she's an information-only role, it's a pretty minimal change.

Closes #87 