### PR TITLE
Automatic Docker builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,80 @@
+---
+name: Build
+# Runs on any commit to master, or manually via the GitHub Actions UI
+on:
+  push:
+    branches:
+      - master
+  workflow_dispatch:  
+    
+jobs:
+  push_server:
+    name: Push Docker image for the API server to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker build artifacts
+        uses: actions/cache@v2
+        with:
+          path: /tmp/buildx-cache
+          # Cache with a key based on the current Git commit
+          key: ${{ runner.os }}-server-buildx-${{ github.sha }}
+          # And restore from any available cache
+          restore-keys: |
+            ${{ runner.os }}-server-buildx-
+      - name: Build and push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          context: thavalon-server
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: theadd336/THavalonWeb/thavalon-server
+          tag_with_ref: true
+          tags: latest
+          cache-from: type=local,src=/tmp/buildx-cache
+          cache-to: type=local,dest=/tmp/buildx-cache-new
+      # Temp fix
+      # https://github.com/docker/build-push-action/issues/252
+      # https://github.com/moby/buildkit/issues/1896
+      - name: Move cache
+        run: |
+          rm -rf /tmp/build-cache
+          mv /tmp/build-cache-new /tmp/build-cache
+  push_webapp:
+    name: Push Docker image for the webapp frontend to GitHub Packages
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v2
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v1
+      - name: Cache Docker build artifacts
+        uses: actions/cache@v2
+        with:
+          path: /tmp/buildx-cache
+          key: ${{ runner.os }}-webapp-buildx-${{ github.sha }}
+          restore-keys: |
+            ${{ runner.os }}-webapp-buildx-
+      - name: Build and push to GitHub Packages
+        uses: docker/build-push-action@v1
+        with:
+          # Unlike the API server, this uses the whole repository as context so that it can
+          # access config files under k8s
+          context: .
+          filename: thavalon-webapp/Dockerfile
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.pkg.github.com
+          repository: theadd336/THavalonWeb/thavalon-webapp
+          tag_with_ref: true
+          tags: latest
+          cache-from: type=local,src=/tmp/buildx-cache
+          cache-to: type=local,dest=/tmp/buildx-cache-new
+      - name: Move cache
+        run: |
+          rm -rf /tmp/build-cache
+          mv /tmp/build-cache-new /tmp/build-cache

--- a/thavalon-server/Dockerfile
+++ b/thavalon-server/Dockerfile
@@ -1,0 +1,16 @@
+# syntax=docker/dockerfile:experimental
+FROM rust:1.46 as builder
+
+COPY . /app
+WORKDIR /app
+
+RUN --mount=type=cache,target=/usr/local/cargo/registry \
+    --mount=type=cache,target=/app/target \
+    cargo install --path .
+
+FROM debian:buster-slim
+
+RUN apt-get update && apt-get -y install ca-certificates libssl-dev && rm -rf /var/lib/apt/lists/*
+COPY --from=builder /usr/local/cargo/bin/thavalon-server /usr/local/bin/thavalon-server
+
+CMD ["/usr/local/bin/thavalon-server"]

--- a/thavalon-server/src/main.rs
+++ b/thavalon-server/src/main.rs
@@ -34,6 +34,7 @@ fn setup_logger() -> Result<(), fern::InitError> {
 #[tokio::main]
 async fn main() {
     setup_logger().expect("Could not set up logging");
+    log::info!("THavalon Server v{}", env!("CARGO_PKG_VERSION"));
     database::initialize_mongo_client().await;
     connections::serve_connections().await;
 }

--- a/thavalon-webapp/Dockerfile
+++ b/thavalon-webapp/Dockerfile
@@ -1,0 +1,14 @@
+# syntax=docker/dockerfile:experimental
+FROM node:latest as builder
+
+WORKDIR /app
+COPY ./thavalon-webapp /app
+
+RUN --mount=type=cache,target=/app/node_modules \
+  npm install && npm run build && mv /app/build /srv/build-output
+
+FROM nginx:latest
+
+COPY --from=builder /srv/build-output /usr/share/nginx/html
+COPY k8s/webapp/default.conf /etc/nginx/conf.d/default.conf
+CMD ["nginx", "-g", "daemon off;"]

--- a/thavalon-webapp/src/components/Home.tsx
+++ b/thavalon-webapp/src/components/Home.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
+import '../styles/Home.scss';
 
 export function Home(): JSX.Element {
     return (
-        <div>
+        <div className="welcome">
             Welcome to Thavalon
         </div>
     );

--- a/thavalon-webapp/src/styles/Home.scss
+++ b/thavalon-webapp/src/styles/Home.scss
@@ -1,0 +1,4 @@
+.welcome {
+    font-size: 1.5rem;
+    font-weight: 500;
+}


### PR DESCRIPTION
This uses GitHub actions to automatically build Docker images. It uses new [caching features](https://github.com/docker/build-push-action/blob/master/docs/advanced/cache.md) so that builds don't have to re-fetch all our dependencies each time. It also automatically pushes to GitHub's Docker image registry, so we can download and run images from there.

The build will run on every commit to master, and can also be triggered manually from GitHub.

## Testing

I built and started the images locally, with a few small changes, to make sure the caching worked. I'm not sure how to test the GitHub Actions part until it's merged, however.